### PR TITLE
In small model, need to write backslashes to %es:(%di), not (%di).

### DIFF
--- a/libgloss/ia16/dos-models-crt0.S
+++ b/libgloss/ia16/dos-models-crt0.S
@@ -188,7 +188,11 @@ _start:
 	call	exit
 
 .Linside_backslash_other:
+#ifdef TINY
 	movb	$'\\',	(%di)
+#else
+	movb	$'\\',	%es:(%di)
+#endif
 	incw	%di
 .Linside_other:
 	stosb
@@ -227,13 +231,17 @@ _start:
 	cmpb	$'\\',	%al
 	je	.Loutside_backslash_backslash
 .Loutside_backslash_other:
+#ifdef TINY
 	movb	$'\\',	(%di)
+#else
+	movb	$'\\',	%es:(%di)
+#endif
 	incw	%di
 	jmp	.Loutside_other
 
 .Loutside_backslash_space:
-	movb	$'\\',	(%di)
-	incw	%di
+	movb	$'\\',	%al
+	stosb
 .Lend_argument:
 	movb	$0,	%al
 	stosb


### PR DESCRIPTION
Otherwise memory is corrupted when the commandline contains
backslashes.