### PR TITLE
Fix nano malloc

### DIFF
--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -525,7 +525,7 @@ void nano_malloc_stats(RONEARG)
 malloc_size_t nano_malloc_usable_size(RARG void * ptr)
 {
     chunk * c = (chunk *)((char *)ptr - CHUNK_OFFSET);
-    int size_or_offset = c->size;
+    long size_or_offset = c->size;
 
     if (size_or_offset < 0)
     {

--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -450,6 +450,7 @@ void * nano_realloc(RARG void * ptr, malloc_size_t size)
 {
     void * mem;
     chunk * p_to_realloc;
+    malloc_size_t oldsize;
 
     if (ptr == NULL) return nano_malloc(RCALL size);
 
@@ -461,13 +462,14 @@ void * nano_realloc(RARG void * ptr, malloc_size_t size)
 
     /* TODO: There is chance to shrink the chunk if newly requested
      * size is much small */
-    if (nano_malloc_usable_size(RCALL ptr) >= size)
+    oldsize = nano_malloc_usable_size(RCALL ptr);
+    if (oldsize >= size)
       return ptr;
 
     mem = nano_malloc(RCALL size);
     if (mem != NULL)
     {
-        memcpy(mem, ptr, size);
+        memcpy(mem, ptr, oldsize);
         nano_free(RCALL ptr);
     }
     return mem;

--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -111,7 +111,7 @@
 
 /* Alignment of allocated block */
 #define MALLOC_ALIGN (8U)
-#define CHUNK_ALIGN (sizeof(void*))
+#define CHUNK_ALIGN (MAX(sizeof(void*), sizeof(long)))
 #define MALLOC_PADDING ((MAX(MALLOC_ALIGN, CHUNK_ALIGN)) - CHUNK_ALIGN)
 
 /* as well as the minimal allocation size
@@ -315,7 +315,7 @@ void * nano_malloc(RARG malloc_size_t s)
 
     if (offset)
     {
-        *(int *)((char *)r + offset) = -offset;
+        ((chunk *)((char *)r + offset))->size = -offset;
     }
 
     assert(align_ptr + size <= (char *)r + alloc_size);
@@ -587,8 +587,8 @@ void * nano_memalign(RARG size_t align, size_t s)
         {
             /* Padding is used. Need to set a jump offset for aligned pointer
             * to get back to chunk head */
-            assert(offset >= sizeof(int));
-            *(int *)((char *)chunk_p + offset) = -offset;
+            assert(offset >= sizeof(long));
+            ((chunk *)((char *)chunk_p + offset))->size = -offset;
         }
     }
 


### PR DESCRIPTION
These fix malloc, free & realloc in newlib for IA16.

background: I ported FreeDOS command.com (freecom) at https://sourceforge.net/p/freedos/svn/HEAD/tree/freecom/trunk/ to ia16-elf-gcc and it's a heavy malloc user. It got into very strange memory corruption errors. The reason is int/long confusion in nano_malloc & friends.