### PR TITLE
Create .bss section for DOS .exe file with (NOLOAD) as in dos-com.ld.

### DIFF
--- a/libgloss/ia16/dos-exe-small.ld
+++ b/libgloss/ia16/dos-exe-small.ld
@@ -100,7 +100,9 @@ SECTIONS
 		*(.data) *(.data.*)
 		*(.gcc_except_table)
 		__edata = .;
+	} >dsegvma AT >bseglma
 
+    .bss (NOLOAD) : {
     	 	 __sbss = .;
                 *(.bss) *(.bss.*)
                 *(COMMON)


### PR DESCRIPTION
This tends to make the executables smaller.

Tested with FreeDOS command.com (which is actually an "exe" file).