### PR TITLE
build libnosys.a before linking to it.

### DIFF
--- a/libgloss/ia16/Makefile.in
+++ b/libgloss/ia16/Makefile.in
@@ -187,13 +187,10 @@ dos-rmdir.o: dos-rmdir.S call-cvt.h
 dos-unlink.o: dos-unlink.S call-cvt.h
 dos-write.o: dos-write.S call-cvt.h
 
-# We need a link to libnosys.a in this directory, since this is the
-# directory used when test-compiling for configuration for other parts and
-# when running the testsuite.  By using a symbolic link, it does not
-# matter whether libnosys.a is built yet when the rule is executed.
 libnosys.a:
+	$(MAKE) -C ../libnosys/ libnosys.a
 	rm -f $@
-	ln -s ../libnosys/libnosys.a
+	ln -s ../libnosys/libnosys.a $@
 
 $(DOS_TINY_BSP) : $(DOS_TINY_OBJS)
 	$(AR) rcs $@ $+


### PR DESCRIPTION
Here's a small fix to support building on mingw, since Windows doesn't allow symlinks to non-existent files.