### PR TITLE
Nanomalloc improve last free chunk

### DIFF
--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -332,14 +332,16 @@ void * nano_malloc(RARG malloc_size_t s)
     if (rem >= MALLOC_MINCHUNK)
     {
         /* Find a chunk that much larger than required size, break
-         * it into two chunks and return the second one */
-        r->size = rem;
-        r = (chunk *)((char *)r + rem);
+         * it into two chunks and return the first one */
+        chunk *rem_r = (chunk *)((char *)r + alloc_size);
+        rem_r->size = rem;
+        rem_r->next = r->next;
         r->size = alloc_size;
+        r->next = rem_r;
     }
     /* Find a chunk that is exactly the size or slightly bigger
      * than requested size, just return this chunk */
-    else if (p == r)
+    if (p == r)
     {
         /* Now it implies p==r==free_list. Move the free_list
          * to next chunk */


### PR DESCRIPTION
There are three commits in here:
1. Cleanup to prep.
2. If the chunk before sbrk(0) is free, extend it instead of creating a new chunk (which created two free chunks in sequence!)
3. When splitting a chunk, return first chunk, second is free. This also helps if the chunk before sbrk(0) is free since it leaves more space at the end, rather then creating a hole there.

This helps FreeCOM memory consumption greatly, from needing a heap > 8K to needing one of just under 5K, while still using the simple "first fit" allocation strategy.